### PR TITLE
GPT-37 refactored so that the type of online services panel to use in…

### DIFF
--- a/src/main/webapp/portal-core/js/portal/widgets/panel/BaseRecordPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/BaseRecordPanel.js
@@ -21,21 +21,24 @@ Ext.define('portal.widgets.panel.BaseRecordPanel', {
     map : null,
     activelayerstore : null,
     menuFactory : null,
+    onlineResourcePanelType : null,
 
     constructor : function(cfg) {
         var me = this;
-        this.map = cfg.map;
-        this.menuFactory = cfg.menuFactory;
-        this.activelayerstore = cfg.activelayerstore;
+        me.map = cfg.map;
+        me.menuFactory = cfg.menuFactory;
+        me.activelayerstore = cfg.activelayerstore;
+        me.onlineResourcePanelType = cfg.onlineResourcePanelType;
+
         var groupingFeature = Ext.create('Ext.grid.feature.Grouping',{
             groupHeaderTpl: '{name} ({[values.rows.length]} {[values.rows.length > 1 ? "Items" : "Item"]})',
             startCollapsed : true
         });
        
-        this.listeners = cfg.listeners;
+        me.listeners = cfg.listeners;
         
-        var menuItems = [this._getVisibleBoundFilterAction(),this._getActivelayerFilterAction(),
-                         this._getDataLayerFilterAction(),this._getImageLayerFilterAction()];
+        var menuItems = [me._getVisibleBoundFilterAction(),me._getActivelayerFilterAction(),
+                         me._getDataLayerFilterAction(),me._getImageLayerFilterAction()];
 
         Ext.apply(cfg, {
             cls : 'auscope-dark-grid',
@@ -73,7 +76,7 @@ Ext.define('portal.widgets.panel.BaseRecordPanel', {
                 //Loading icon column
                 xtype : 'clickcolumn',
                 dataIndex : 'active',
-                renderer : this._deleteRenderer,
+                renderer : me._deleteRenderer,
                 hasTip : true,
                 tipRenderer : function(value, layer, column, tip) {
                     if(layer.get('active')){
@@ -84,51 +87,51 @@ Ext.define('portal.widgets.panel.BaseRecordPanel', {
                 },
                 width: 32,
                 listeners : {
-                    columnclick : Ext.bind(this._deleteClickHandler, this)
+                    columnclick : Ext.bind(me._deleteClickHandler, me)
                 }
             },{
                 //Loading icon column
                 xtype : 'clickcolumn',
                 dataIndex : 'loading',
-                renderer : this._loadingRenderer,
+                renderer : me._loadingRenderer,
                 hasTip : true,
-                tipRenderer : Ext.bind(this._loadingTipRenderer, this),
+                tipRenderer : Ext.bind(me._loadingTipRenderer, me),
                 width: 32,
                 listeners : {
-                    columnclick : Ext.bind(this._loadingClickHandler, this)
+                    columnclick : Ext.bind(me._loadingClickHandler, me)
                 }
             },{
                 //Title column
                 text : 'Title',
                 dataIndex : 'name',
                 flex: 1,
-                renderer : this._titleRenderer
+                renderer : me._titleRenderer
             },{
                 //Service information column
                 xtype : 'clickcolumn',
                 dataIndex : 'serviceInformation',
                 width: 32,
-                renderer : this._serviceInformationRenderer,
+                renderer : me._serviceInformationRenderer,
                 hasTip : true,
                 tipRenderer : function(value, layer, column, tip) {
                     return 'Click for detailed information about the web services this layer utilises.';
                 },
                 listeners : {
-                    columnclick : Ext.bind(this._serviceInformationClickHandler, this)
+                    columnclick : Ext.bind(me._serviceInformationClickHandler, me)
                 }
             },{
                 //Spatial bounds column
                 xtype : 'clickcolumn',
                 dataIndex : 'spatialBoundsRenderer',
                 width: 32,
-                renderer : this._spatialBoundsRenderer,
+                renderer : me._spatialBoundsRenderer,
                 hasTip : true,
                 tipRenderer : function(value, layer, column, tip) {
                     return 'Click to see the bounds of this layer, double click to pan the map to those bounds.';
                 },
                 listeners : {
-                    columnclick : Ext.bind(this._spatialBoundsClickHandler, this),
-                    columndblclick : Ext.bind(this._spatialBoundsDoubleClickHandler, this)
+                    columnclick : Ext.bind(me._spatialBoundsClickHandler, me),
+                    columndblclick : Ext.bind(me._spatialBoundsDoubleClickHandler, me)
                 }
             }],
           plugins:[{                
@@ -147,7 +150,7 @@ Ext.define('portal.widgets.panel.BaseRecordPanel', {
                   record.set('layer',newLayer);
                   var filterForm = cfg.layerFactory.formFactory.getFilterForm(newLayer).form; //ALWAYS recreate filter form - see https://jira.csiro.au/browse/AUS-2588
                   filterForm.setLayer(newLayer);
-                  var filterPanel = me._getInlineLayerPanel(filterForm, parentElId, this);
+                  var filterPanel = me._getInlineLayerPanel(filterForm, parentElId, me);
                   
                   //Update the layer panel to use
                   if (filterForm) {
@@ -157,7 +160,7 @@ Ext.define('portal.widgets.panel.BaseRecordPanel', {
                           filterForm.getForm().setValues(existingParams);
                       }
                   }
-                  this.grid.updateLayout({
+                  me.grid.updateLayout({
                       defer:false,
                       isRoot:false
                   });                    
@@ -169,7 +172,7 @@ Ext.define('portal.widgets.panel.BaseRecordPanel', {
                   
         });
 
-        this.callParent(arguments);
+        me.callParent(arguments);
     },
     
     
@@ -517,7 +520,8 @@ Ext.define('portal.widgets.panel.BaseRecordPanel', {
 
         var popup = Ext.create('portal.widgets.window.CSWRecordDescriptionWindow', {
             cswRecords : cswRecords,
-            parentRecord : record
+            parentRecord : record,
+            onlineResourcePanelType : this.onlineResourcePanelType
         });
 
         popup.show();

--- a/src/main/webapp/portal-core/js/portal/widgets/window/CSWRecordDescriptionWindow.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/window/CSWRecordDescriptionWindow.js
@@ -9,10 +9,13 @@ Ext.define('portal.widgets.window.CSWRecordDescriptionWindow', {
      *  cfg can contain all the elements for Ext.Window along with the following additions
      *
      *  cswRecords - a CSWRecord or Array of CSWRecords - these will generate the contents of this window.
+     *  parentRecord - the parent layer
+     *  onlineResourcePanelType A specific subclass of online resource panel to use
      */
     constructor : function(cfg) {
         var cswRecords = cfg.cswRecords;
         var parentRecord = cfg.parentRecord;
+        var onlineResourcePanelType = cfg.onlineResourcePanelType || 'onlineresourcepanel';        
 
         //Set our default values (if they haven't been set)
         Ext.applyIf(cfg, {
@@ -40,7 +43,7 @@ Ext.define('portal.widgets.window.CSWRecordDescriptionWindow', {
             Ext.apply(cfg, {
                 autoScroll : true,
                 items : [{
-                    xtype : 'onlineresourcepanel',
+                    xtype : onlineResourcePanelType,
                     cswRecords : cswRecords,
                     parentRecord : parentRecord
                 }],


### PR DESCRIPTION
… the service information dialog can be specified in the portal proper. Because this is now available I rolled back all of the changes I made to Auscope-portal's version of the OnlineServicesPanel.

I also changed a bunch of "this" to "me". Maybe I should not have done that in this commit. The reason to use "me" is because it optimises better. It's not a functional change so I thought I would just do it here, but I'm open to undoing this if anyone objects.