### PR TITLE
GPT-40 - Add Surface Geology Layers - AND/OR functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .project
 .settings/
 target/
+.buildpath

--- a/src/main/java/org/auscope/portal/core/services/KnownLayerService.java
+++ b/src/main/java/org/auscope/portal/core/services/KnownLayerService.java
@@ -5,6 +5,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.auscope.portal.core.services.responses.csw.CSWRecord;
 import org.auscope.portal.core.view.knownlayer.KnownLayer;
 import org.auscope.portal.core.view.knownlayer.KnownLayerAndRecords;
@@ -18,6 +20,8 @@ import org.auscope.portal.core.view.knownlayer.KnownLayerSelector;
  *
  */
 public class KnownLayerService {
+    private final Log logger = LogFactory.getLog(getClass().getName());
+
     private List<KnownLayer> knownLayers;
     private CSWCacheService cswCacheService;
 
@@ -75,6 +79,7 @@ public class KnownLayerService {
 
         //Figure out what records belong to which known layers (could be multiple)
         for (KnownLayer knownLayer : knownLayers) {
+            logger.debug("groupKnownLayerRecords - knownLayer: "+knownLayer);
             // We have to do this part regardless of the classFilters because
             // if not, the results for unmappedRecords will be incorrect.
             // (I.e.: they'll include related features from things that have
@@ -96,6 +101,11 @@ public class KnownLayerService {
                     belongingRecords.add(record);
                     mappedRecordIDs.put(record.getFileIdentifier(), null);
                     break;
+                case NotRelated:
+                    break;
+                default:
+                    throw new RuntimeException(
+                            "This must be a new isRelatedRecord: " + selector.isRelatedRecord(record));
                 }
             }
 
@@ -131,7 +141,7 @@ public class KnownLayerService {
                 unmappedRecords.add(record);
             }
         }
-
-        return new KnownLayerGrouping(knownLayerAndRecords, unmappedRecords, originalRecordList);
+        KnownLayerGrouping knownLayerGrouping = new KnownLayerGrouping(knownLayerAndRecords, unmappedRecords, originalRecordList);
+        return knownLayerGrouping;
     }
 }

--- a/src/main/java/org/auscope/portal/core/view/ViewKnownLayerFactory.java
+++ b/src/main/java/org/auscope/portal/core/view/ViewKnownLayerFactory.java
@@ -4,6 +4,9 @@ import java.awt.Dimension;
 import java.awt.Point;
 
 import org.auscope.portal.core.view.knownlayer.KnownLayer;
+import org.auscope.portal.core.view.knownlayer.KnownLayerSelector;
+import org.auscope.portal.core.view.knownlayer.SelectorsMode;
+import org.auscope.portal.core.view.knownlayer.WMSSelectors;
 import org.springframework.ui.ModelMap;
 
 /**
@@ -51,6 +54,19 @@ public class ViewKnownLayerFactory {
             group = k.getGroup();
         }
         obj.put("group", group);
+        
+        // LayersMode is from GA GPT-41 where Layers can have Layers and they can be 'OR'd or 'AND'd.
+        if (k.getKnownLayerSelector() != null) {
+            KnownLayerSelector knownLayerSelector = k.getKnownLayerSelector();
+            if (knownLayerSelector instanceof WMSSelectors) {
+                WMSSelectors wmsSelectors = (WMSSelectors) knownLayerSelector;
+                obj.put("layerMode", wmsSelectors.getLayersMode());
+            } else {
+                obj.put("layerMode", SelectorsMode.NA);
+            }
+        } else {
+            obj.put("layerMode", SelectorsMode.NA);
+        }
 
         return obj;
     }

--- a/src/main/java/org/auscope/portal/core/view/knownlayer/KnownLayer.java
+++ b/src/main/java/org/auscope/portal/core/view/knownlayer/KnownLayer.java
@@ -354,4 +354,19 @@ public class KnownLayer implements Serializable {
         this.order = order;
         logger.info(String.format("setOrder - group: %s, name: %s, order: %d", getGroup(), getName(), getOrder()));
     }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "KnownLayer [name=" + name + ", id=" + id + ", description=" + description + ", hidden=" + hidden
+                + ", group=" + group + ", proxyUrl=" + proxyUrl + ", proxyCountUrl=" + proxyCountUrl
+                + ", proxyStyleUrl=" + proxyStyleUrl + ", proxyDownloadUrl=" + proxyDownloadUrl
+                + ", knownLayerSelector=" + knownLayerSelector + ", iconUrl=" + iconUrl + ", polygonColor="
+                + polygonColor + ", iconAnchor=" + iconAnchor + ", iconSize=" + iconSize + ", feature_count="
+                + feature_count + ", order=" + order + "]";
+    }
+    
+    
 }

--- a/src/main/java/org/auscope/portal/core/view/knownlayer/KnownLayerAndRecords.java
+++ b/src/main/java/org/auscope/portal/core/view/knownlayer/KnownLayerAndRecords.java
@@ -61,4 +61,12 @@ public class KnownLayerAndRecords {
         return relatedRecords;
     }
 
+    /* (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "KnownLayerAndRecords [knownLayer=" + knownLayer + ", belongingRecords=" + belongingRecords
+                + ", relatedRecords=" + relatedRecords + "]";
+    }
 }

--- a/src/main/java/org/auscope/portal/core/view/knownlayer/KnownLayerGrouping.java
+++ b/src/main/java/org/auscope/portal/core/view/knownlayer/KnownLayerGrouping.java
@@ -52,4 +52,12 @@ public class KnownLayerGrouping {
         return originalRecordSet;
     }
 
+    /* (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "KnownLayerGrouping [knownLayers=" + knownLayers + ", unmappedRecords=" + unmappedRecords
+                + ", originalRecordSet=" + originalRecordSet + "]";
+    }
 }

--- a/src/main/java/org/auscope/portal/core/view/knownlayer/SelectorsMode.java
+++ b/src/main/java/org/auscope/portal/core/view/knownlayer/SelectorsMode.java
@@ -1,0 +1,12 @@
+/**
+ * 
+ */
+package org.auscope.portal.core.view.knownlayer;
+
+/**
+ * @author u86990
+ *
+ */
+public enum SelectorsMode {
+    NA,OR,AND
+}

--- a/src/main/java/org/auscope/portal/core/view/knownlayer/WMSSelector.java
+++ b/src/main/java/org/auscope/portal/core/view/knownlayer/WMSSelector.java
@@ -1,5 +1,7 @@
 package org.auscope.portal.core.view.knownlayer;
 
+import java.util.Arrays;
+
 import org.auscope.portal.core.services.responses.csw.AbstractCSWOnlineResource;
 import org.auscope.portal.core.services.responses.csw.AbstractCSWOnlineResource.OnlineResourceType;
 import org.auscope.portal.core.services.responses.csw.CSWRecord;
@@ -136,5 +138,15 @@ public class WMSSelector implements KnownLayerSelector {
 
     public boolean includeEndpoints() {
         return includeEndpoints;
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "WMSSelector [layerName=" + layerName + ", relatedLayerNames=" + Arrays.toString(relatedLayerNames)
+                + ", serviceEndpoints=" + Arrays.toString(serviceEndpoints) + ", includeEndpoints=" + includeEndpoints
+                + "]";
     }
 }

--- a/src/main/java/org/auscope/portal/core/view/knownlayer/WMSSelectors.java
+++ b/src/main/java/org/auscope/portal/core/view/knownlayer/WMSSelectors.java
@@ -1,0 +1,77 @@
+/**
+ * 
+ */
+package org.auscope.portal.core.view.knownlayer;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.auscope.portal.core.services.responses.csw.CSWRecord;
+
+/**
+ * This class is for handling multiple layers to group them together in some way. Either they are 'AND'ed and all layers show together effectively on-top of
+ * each other. This is most relevant where there are complementary layers that show the same features but at different scales - one might show at scales less
+ * than 1:x and another might show at scales greater (equal) 1:x. Written as part of GPT-41 for Geoscience Surface Geology layer group.
+ * 
+ * @author Brooke Smith
+ * 
+ */
+public class WMSSelectors implements KnownLayerSelector {
+
+    private List<WMSSelector> wmsSelectors;
+    private SelectorsMode layersMode;
+
+    private WMSSelectors() {
+        super();
+    }
+
+    public WMSSelectors(SelectorsMode layersMode, List<String> layerNames) {
+        this();
+        this.layersMode = layersMode;
+        wmsSelectors = new ArrayList<WMSSelector>();
+        for (String layerName : layerNames) {
+            WMSSelector wmsSelector = new WMSSelector(layerName);
+            wmsSelectors.add(wmsSelector);
+            // Now set the other layers as related
+            Set<String> otherLayerNames = new HashSet<>(layerNames);
+            otherLayerNames.remove(layerName);
+            wmsSelector.setRelatedLayerNames(otherLayerNames.toArray(new String[0]));
+        }
+    }
+
+    /**
+     * @return the layersMode
+     */
+    public SelectorsMode getLayersMode() {
+        return layersMode;
+    }
+
+    /**
+     * @param layersMode
+     *            the layersMode to set
+     */
+    public void setLayersMode(SelectorsMode layersMode) {
+        this.layersMode = layersMode;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.auscope.portal.core.view.knownlayer.KnownLayerSelector#isRelatedRecord(org.auscope.portal.core.services.responses.csw.CSWRecord)
+     * 
+     * We need to get the RelationType for all wmsSelectors and return the 'greatest' one (Belongs, Related, Not Related is strongest to weakest). And we only
+     * want to return one of each type or else we'll get multiply defined records - subsequent ones are 'Not Related'
+     */
+    @Override
+    public RelationType isRelatedRecord(CSWRecord record) {
+        RelationType greatestRelationship = RelationType.NotRelated;
+        for (WMSSelector selector : wmsSelectors) {
+            if (selector.isRelatedRecord(record).ordinal() > greatestRelationship.ordinal()) {
+                greatestRelationship = selector.isRelatedRecord(record);
+            }
+        }
+        return greatestRelationship;
+    }
+}

--- a/src/main/webapp/portal-core/js/portal/layer/renderer/wms/DisjunctionLayerRenderer.js
+++ b/src/main/webapp/portal-core/js/portal/layer/renderer/wms/DisjunctionLayerRenderer.js
@@ -1,0 +1,111 @@
+/**
+ * An implementation of a portal.layer.Renderer for rendering WMS Layers that belong to a set of portal.csw.CSWRecord
+ * objects. This extension is for Disjuncted ("OR") Layers of Layers defined through a WFSSelectors KnownLayerSelector
+ * (in auscope-known-layers.xml) and was developed by GA in GPT-40.
+ */
+Ext.define('portal.layer.renderer.wms.DisjunctionLayerRenderer', {
+    extend : 'portal.layer.renderer.Renderer',
+
+    constructor : function(config) {
+        this.legend = Ext.create('portal.layer.legend.wfs.WMSLegend', {
+            iconUrl : config.iconCfg ? config.iconCfg.url : 'portal-core/img/key.png'
+        });
+        this.callParent(arguments);
+    },
+
+    /**
+     * A function for displaying layered data from a variety of data sources. This function will raise the renderstarted
+     * and renderfinished events as appropriate. The effect of multiple calls to this function (ie calling displayData
+     * again before renderfinished is raised) is undefined.
+     * 
+     * This function will re-render itself entirely and thus may call removeData() during the normal operation of this
+     * function
+     * 
+     * function(portal.csw.OnlineResource[] resources, portal.layer.filterer.Filterer filterer,
+     * function(portal.layer.renderer.Renderer this, portal.csw.OnlineResource[] resources,
+     * portal.layer.filterer.Filterer filterer, bool success) callback
+     * 
+     * returns - void
+     * 
+     * resources - an array of data sources which should be used to render data filterer - A custom filter that can be
+     * applied to the specified data sources callback - Will be called when the rendering process is completed and
+     * passed an instance of this renderer and the parameters used to call this function
+     */
+    displayData : function(resources, filterer, callback) {
+        this.removeData();
+        var wmsResources = portal.csw.OnlineResource.getFilteredFromArray(resources, portal.csw.OnlineResource.WMS);
+
+        var urls = [];
+        for (var i = 0; i < wmsResources.length; i++) {
+            urls.push(wmsResources[i].get('url'));
+        }
+        this.renderStatus.initialiseResponses(urls, 'Loading...');
+
+
+        var primitives = [];
+        for (var i = 0; i < wmsResources.length; i++) {
+            // Find the layer.name that is the same as the selected one
+            var wmsLayer = wmsResources[i].get('name');
+            if (wmsLayer === filterer.getParameter('serviceFilter')) {
+                var wmsUrl = wmsResources[i].get('url');
+                var wmsOpacity = filterer.getParameter('opacity');
+
+                var layer = this.map.makeWms(undefined, undefined, wmsResources[i], this.parentLayer, wmsUrl, wmsLayer,
+                        wmsOpacity);
+
+                layer.getWmsLayer().events.register("loadstart", this, function() {
+                    this.currentRequestCount++;
+                    var listOfStatus = this.renderStatus.getParameters();
+                    this.fireEvent('renderstarted', this, wmsResources, filterer);
+                    this.renderStatus.updateResponse(layer.getWmsUrl(), "Loading WMS");
+                });
+
+                // VT: Handle the after wms load clean up event.
+                layer.getWmsLayer().events.register("loadend", this, function(evt) {
+                    this.currentRequestCount--;
+                    var listOfStatus = this.renderStatus.getParameters();
+                    this.renderStatus.updateResponse(layer.getWmsUrl(), "WMS Loaded");
+                    this.fireEvent('renderfinished', this);
+                });
+
+                primitives.push(layer);
+            }
+        }
+
+        this.primitiveManager.addPrimitives(primitives);
+        this.hasData = true;
+
+    },
+
+    /**
+     * A function for creating a legend that can describe the displayed data. If no such thing exists for this renderer
+     * then null should be returned.
+     * 
+     * function(portal.csw.OnlineResource[] resources, portal.layer.filterer.Filterer filterer)
+     * 
+     * returns - portal.layer.legend.Legend or null
+     * 
+     * resources - (same as displayData) an array of data sources which should be used to render data filterer - (same
+     * as displayData) A custom filter that can be applied to the specified data sources
+     */
+    getLegend : function(resources, filterer) {
+        return this.legend;
+    },
+
+    /**
+     * A function that is called when this layer needs to be permanently removed from the map. In response to this
+     * function all rendered information should be removed
+     * 
+     * function()
+     * 
+     * returns - void
+     */
+    removeData : function() {
+        this.primitiveManager.clearPrimitives();
+    },
+
+    /**
+     * You can't abort a WMS layer from rendering as it does so via img tags
+     */
+    abortDisplay : Ext.emptyFn
+});

--- a/src/main/webapp/portal-core/jsimports.htm
+++ b/src/main/webapp/portal-core/jsimports.htm
@@ -115,6 +115,7 @@
 <script src="portal-core/js/portal/layer/renderer/kml/KMLRenderer.js" type="text/javascript"></script>
 
 <script src="portal-core/js/portal/layer/renderer/wms/LayerRenderer.js" type="text/javascript"></script>
+<script src="portal-core/js/portal/layer/renderer/wms/DisjunctionLayerRenderer.js" type="text/javascript"></script>
 <script src="portal-core/js/portal/layer/Layer.js" type="text/javascript"></script>
 <script src="portal-core/js/portal/layer/LayerFactory.js" type="text/javascript"></script>
 <script src="portal-core/js/portal/layer/LayerStore.js" type="text/javascript"></script>

--- a/src/test/java/org/auscope/portal/core/view/knownlayer/RelationTypeTest.java
+++ b/src/test/java/org/auscope/portal/core/view/knownlayer/RelationTypeTest.java
@@ -1,0 +1,39 @@
+/**
+ * 
+ */
+package org.auscope.portal.core.view.knownlayer;
+
+import org.auscope.portal.core.view.knownlayer.KnownLayerSelector.RelationType;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author u86990
+ *
+ */
+public class RelationTypeTest {
+
+    @Test
+    public void testRelationTypeRelationships01() {
+        RelationType left = RelationType.Belongs;
+        RelationType right = RelationType.Related;
+        
+        Assert.assertTrue(left.ordinal() > right.ordinal());
+    }
+
+    @Test
+    public void testRelationTypeRelationships02() {
+        RelationType left = RelationType.Belongs;
+        RelationType right = RelationType.NotRelated;
+        
+        Assert.assertTrue(left.ordinal() > right.ordinal());
+    }
+    
+    @Test
+    public void testRelationTypeRelationships03() {
+        RelationType left = RelationType.Related;
+        RelationType right = RelationType.NotRelated;
+        
+        Assert.assertTrue(left.ordinal() > right.ordinal());
+    }
+}


### PR DESCRIPTION
These commits had been sitting waiting on feedback for this feature to go ahead and in the meantime my repository became corrupted.  I've fixed it up now and want to create a pull request for this work.  As far as I understand it, Ollie wants this functionality or something very closes to it.  The layers I've setup may be wrong.  But the functionality is what I want to commit and we can fix the layers later.

Commits from original commits:
1. GPT-40 - Layers in layers (AND | OR) - Intermediate
   commit as have the AND case going (needs cleanup inc. only doing when
   LayerMode == "AND") and have started OR case and have identified I need to
   put in a Renderer for this case.  I'm a little unsure of this and will commit
   before attempting that (I've asked Josh Long to confirm this is the way to
   go).
2. GPT-40 - Layers in layers (AND | OR) - The "OR" case is
   now working (though I realized it isn't - the layers are all appearing).
   Ollie has said to stop work on this and I am doing so, but committing locally
   first. \* Added new layers for 2500k \* Added new renderer
   (portal.layer.renderer.wms.DisjunctionLayerRenderer) (in portal-core) and
   used in geoscience-portal

This has accompanying work in geoscience-portal I will now create a pull request for also.
