### PR TITLE
GPT-103 - ANDed layers order - Fixed NPE

### DIFF
--- a/src/main/java/org/auscope/portal/core/services/responses/csw/CSWRecord.java
+++ b/src/main/java/org/auscope/portal/core/services/responses/csw/CSWRecord.java
@@ -111,6 +111,7 @@ public class CSWRecord {
         this.descriptiveKeywords = new String[0];
         this.constraints = new String[0];
         this.noCache = false;
+        this.layerName = "";    // Prevents an NPE that must be occurring if this is not set and remains null.
 
         logger.trace(this.toString());
     }

--- a/src/main/java/org/auscope/portal/core/services/responses/csw/CSWRecord.java
+++ b/src/main/java/org/auscope/portal/core/services/responses/csw/CSWRecord.java
@@ -112,6 +112,7 @@ public class CSWRecord {
         this.constraints = new String[0];
         this.noCache = false;
         this.layerName = "";    // Prevents an NPE that must be occurring if this is not set and remains null.
+        // TODO - remove previous comment when GPT-103 NPE problem is worked out
 
         logger.trace(this.toString());
     }

--- a/src/test/java/org/auscope/portal/core/services/KnownLayerServiceTest.java
+++ b/src/test/java/org/auscope/portal/core/services/KnownLayerServiceTest.java
@@ -291,15 +291,23 @@ public class KnownLayerServiceTest {
 //    }
 
     /**
-     * @param cswRecordList
-     * @return
+     * We have a bug related to GPT-103 Fix order of Anded Layers.  I'm investigating possible reasons (the stack trace isn't really helping and I can't reproduce it on my macine - it only happens on the server).
+     * 
+     * I'm investing what happens if CSWRecord.layer is null.  A use is:
+     * 
+     *             int indexInWMSSelectorsList = layerNames.indexOf(record.getLayerName());
+     *    
+     * Look at what various values do.
      */
-    private Iterable<String> getServiceNames(List<CSWRecord> cswRecordList) {
-        List<String> serviceNames = new ArrayList<>();
+    @Test
+    public void testIndexOfVariousValues() {
+        String nullString = null;
+        String emptyString = "";
+        String data = "blah blah blah";
         
-        for (CSWRecord cswRecord : cswRecordList) {
-            serviceNames.add(cswRecord.getServiceName());
-        }
-        return serviceNames;
+        // no problem
+        data.indexOf(emptyString);
+        // Gives an NPE - i think this is our problem.
+        data.indexOf(nullString);
     }
 }


### PR DESCRIPTION
- I think I did 
- There was no problem on my dev box but on the server an NPE would occur.  I tested for a possible situation that may arise in the code I'd added previously on this branch and believe defaulting CSWRecord.layerName to "" (instead of Null) may solve the problem causing an NPE.
