### PR TITLE
NO ISSUE - Fix failure on deploy

### DIFF
--- a/src/main/webapp/portal-core/js/portal/map/openlayers/primitives/WMSOverlay.js
+++ b/src/main/webapp/portal-core/js/portal/map/openlayers/primitives/WMSOverlay.js
@@ -45,7 +45,7 @@ Ext.define('portal.map.openlayers.primitives.WMSOverlay', {
             projection: cswboundingBox.crs,
             maxExtent: cswboundingBox.bounds,
             tileOrigin: new OpenLayers.LonLat(-20037508.34, -20037508.34),
-            displayInLayerSwitcher : false,
+            displayInLayerSwitcher : false
         };
         
         if (singleTile == true) {


### PR DESCRIPTION
Trailing comma was causing failure on portal-core build when deploying to DEV.

From Jenkins log:

> `[ERROR] portal-core-all.js:19119: ERROR - Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option.`
> 
> `displayInLayerSwitcher : false,`
