### PR TITLE
GPT-152 Allow for SLDs with ArcGIS WMS

### DIFF
--- a/src/main/java/org/auscope/portal/core/view/ViewKnownLayerFactory.java
+++ b/src/main/java/org/auscope/portal/core/view/ViewKnownLayerFactory.java
@@ -48,6 +48,7 @@ public class ViewKnownLayerFactory {
         obj.put("feature_count", k.getFeature_count());
         obj.put("order", k.getOrder());
         obj.put("singleTile", k.getSingleTile());
+        obj.put("forceWMSGet", k.getForceWMSGet());
         obj.put("staticLegendUrl", k.getStaticLegendUrl());
         
         String group = "Others";

--- a/src/main/java/org/auscope/portal/core/view/knownlayer/KnownLayer.java
+++ b/src/main/java/org/auscope/portal/core/view/knownlayer/KnownLayer.java
@@ -68,6 +68,12 @@ public class KnownLayer implements Serializable {
      * (many is the default).
      */
     private Boolean singleTile = Boolean.FALSE;
+    
+    /** For cases where POSTing an SLD to a WMS service is not possible (eg ArcGIS) 
+     *  (default is not to force and let the JS framework decide based on URL length
+     *  which usually results in a POST)   
+     */
+    private Boolean forceWMSGet = Boolean.FALSE;
 
     /** A URL to use to grab a canned legend graphic for the layer (optional). */
     private String staticLegendUrl;
@@ -367,7 +373,15 @@ public class KnownLayer implements Serializable {
         this.singleTile = singleTile;
     }
 
-    public String getStaticLegendUrl() {
+	public Boolean getForceWMSGet() {
+		return forceWMSGet;
+	}
+
+	public void setForceWMSGet(Boolean forceWMSGet) {
+		this.forceWMSGet = forceWMSGet;
+	}
+
+	public String getStaticLegendUrl() {
         return staticLegendUrl;
     }
 

--- a/src/main/java/org/auscope/portal/core/view/knownlayer/KnownLayer.java
+++ b/src/main/java/org/auscope/portal/core/view/knownlayer/KnownLayer.java
@@ -381,7 +381,7 @@ public class KnownLayer implements Serializable {
 		this.forceWMSGet = forceWMSGet;
 	}
 
-	public String getStaticLegendUrl() {
+    public String getStaticLegendUrl() {
         return staticLegendUrl;
     }
 

--- a/src/main/webapp/portal-core/js/portal/knownlayer/KnownLayer.js
+++ b/src/main/webapp/portal-core/js/portal/knownlayer/KnownLayer.js
@@ -33,6 +33,7 @@ Ext.define('portal.knownlayer.KnownLayer', {
         { name: 'feature_count', type: 'string'}, //GetFeatureInfo feature_count attribute, 0 would be to default to whatever is set on the server.
         { name: 'order', type: 'string'},	// Order of the layers within a group
         { name: 'singleTile', type: 'boolean'},    // Whether the layer should be requested as a single image (ie not tiled)
+        { name: 'forceWMSGet', type: 'boolean'},    // Whether the layer should always use a GET request for WMS
         { name: 'staticLegendUrl', type: 'string'}    // A URL to use to grab a canned legend graphic for the layer, optional.
     ],
 

--- a/src/main/webapp/portal-core/js/portal/map/openlayers/primitives/WMSOverlay.js
+++ b/src/main/webapp/portal-core/js/portal/map/openlayers/primitives/WMSOverlay.js
@@ -28,6 +28,7 @@ Ext.define('portal.map.openlayers.primitives.WMSOverlay', {
         }        
                         
         var singleTile = cfg.layer.get('source').get('singleTile');
+        var forceWMSGet = cfg.layer.get('source').get('forceWMSGet');
         
         var cswboundingBox= this._getCSWBoundingBox(cswRecord);        
 
@@ -40,7 +41,7 @@ Ext.define('portal.map.openlayers.primitives.WMSOverlay', {
         };
                 
         var additionalOptions = {
-            tileOptions: {maxGetUrlLength: 1500},
+            tileOptions: {},
             isBaseLayer : false,
             projection: cswboundingBox.crs,
             maxExtent: cswboundingBox.bounds,
@@ -51,6 +52,10 @@ Ext.define('portal.map.openlayers.primitives.WMSOverlay', {
         if (singleTile == true) {
             additionalOptions.singleTile = true;
             additionalOptions.ratio = 1;
+        }
+        
+        if (forceWMSGet == false) {
+        	additionalOptions.tileOptions.maxGetUrlLength = 1500;
         }
         
         if(this.getSld_body() && this.getSld_body().length > 0){            


### PR DESCRIPTION
Parameter 'forceWMSGet' added to KnownLayers config. An optional parameter that if set to true will override the UI framework choosing POST based on URL length.
