### PR TITLE
Another hacky check for ArcGIS

### DIFF
--- a/src/main/webapp/portal-core/js/portal/layer/legend/wms/WMSLegend.js
+++ b/src/main/webapp/portal-core/js/portal/layer/legend/wms/WMSLegend.js
@@ -91,7 +91,7 @@ Ext.define('portal.layer.legend.wms.WMSLegend', {
             // GPT-MS -- I don't believe the below works. GetLegendGraphic takes a STYLE parameter, not a STYLES parameter. Have left it as is. 
             if (this.styles) {
                 url += '&STYLES=' + escape(this.styles);
-            } else {
+            } else if (wmsURL.toUpperCase().indexOf("MAPSERVER/WMSSERVER") > -1){
             	var sld = portal.util.xml.SimpleDOM.parseStringToDOM(sld_body);
             	// GPT-MS : This would be better as an XPath '/StyledLayerDescriptor/UserStyle/Name" but I couldn't get it to work.  
             	url += '&STYLE=' + sld.getElementsByTagName("UserStyle")[0].getElementsByTagName("Name")[0].textContent;


### PR DESCRIPTION
The eternally frustrating situation of compatibility between ArcGIS and Geoserver.

Difference in behaviour encountered here:

If an SLD is to be applied to an ArcGIS GetLegendGraphic request, the STYLE parameter must match the UserStyle/Name in the SLD of the style you wish to apply.
For a Geoserver GetLegendGraphic, the STYLE parameter must match a style that has been predefined server side, the SLD is ignored if this parameter is used.
This was not detected, as by serendipity most of the STYLE parameters in the SLDs we were sending to Geoserver matched their predefined styles that were configured server side ("portal-style").
So to get around this, we check if its an ArcGIS service we're using.
