### PR TITLE
GPT-253 Remove hardcoding of URL

### DIFF
--- a/src/main/webapp/portal-core/js/portal/layer/querier/wms/GeotransectQuerier.js
+++ b/src/main/webapp/portal-core/js/portal/layer/querier/wms/GeotransectQuerier.js
@@ -91,13 +91,7 @@ Ext.define('portal.layer.querier.wms.GeotransectQuerier', {
                         var cswUrl = portal.util.xml.SimpleXPath.evaluateXPathString(domDoc.childNodes[0], "//*[local-name()='FIELDS']/@url");
                     }
 
-                    //VT: The response back from GA is a invalid url. Further it gets redirected to another URL
-                    //VT: therefore concatenating /xml to the returned url won't work.
-                    //VT: Rini advise to hardcode the URL.
-                    //https://www.ga.gov.au/products/servlet/controller?event=GEOCAT_DETAILS&amp;catno=76436
-                    var startIndex= cswUrl.lastIndexOf("catno=") + 6;
-                    var catno = cswUrl.substring(startIndex,cswUrl.length);
-                    cswUrl = "http://www.ga.gov.au/metadata-gateway/metadata/record/gcat_" + catno + "/xml";
+                    cswUrl = cswUrl + "/xml";
                     this._getCSWRecord(cswUrl,queryTarget,callback);
                 }else{
                     callback(this, [this.generateErrorComponent('There was an error when attempting to contact the remote WMS instance for information about this point.')], queryTarget);


### PR DESCRIPTION
Onshore Seismic Surveys endpoint has been updated. The dataset
contains the correct URLs and we no longer need to hardcode.
Please update your metadata catalogs to reflect the new endpoint.

http://services.ga.gov.au/gis/services/Onshore_Seismic_Surveys/MapServer/WMSServer
