### PR TITLE
GPT-253 Remove check for SLD tag

### DIFF
--- a/src/main/webapp/portal-core/js/portal/layer/renderer/wms/LayerRenderer.js
+++ b/src/main/webapp/portal-core/js/portal/layer/renderer/wms/LayerRenderer.js
@@ -78,7 +78,7 @@ Ext.define('portal.layer.renderer.wms.LayerRenderer', {
         if (response !== null) {
             var sld_body = response.responseText;
             this.sld_body = sld_body;
-            if(sld_body.indexOf("<?xml version=")!=0 && sld_body.indexOf("<StyledLayerDescriptor") != 0){
+            if(sld_body.indexOf("<?xml version=")!=0){
                 this._updateStatusforWMS(wmsUrl, "error: invalid SLD response");
                 return
             }


### PR DESCRIPTION
Service end point for scanned maps has been updated, accepts
XML declaraion, meaning we no longer require the SLD check.
