### PR TITLE
Limit Nagios failing hosts flag

### DIFF
--- a/src/main/java/org/auscope/portal/core/server/controllers/BaseCSWController.java
+++ b/src/main/java/org/auscope/portal/core/server/controllers/BaseCSWController.java
@@ -104,12 +104,14 @@ public abstract class BaseCSWController extends BasePortalController {
 
             List<ModelMap> viewMappedRecords = new ArrayList<>();
 
-            Set<URL> onlineResourceEndpoints = new HashSet<>();
+            Set<String> onlineResourceEndpoints = new HashSet<>();
             for (CSWRecord rec : knownLayerAndRecords.getBelongingRecords()) {
 
                 if (rec != null) {
                     for (AbstractCSWOnlineResource onlineResource : rec.getOnlineResources()) {
-                        onlineResourceEndpoints.add(onlineResource.getLinkage());
+                        if (onlineResource.getLinkage() != null) {
+                            onlineResourceEndpoints.add(onlineResource.getLinkage().getHost());
+                        }
                     }
                     viewMappedRecords.add(viewCSWRecordFactory.toView(rec));
                 }
@@ -132,13 +134,10 @@ public abstract class BaseCSWController extends BasePortalController {
                     for (Entry<String, List<ServiceStatusResponse>> entry : response.entrySet()) {
                         for (ServiceStatusResponse status : entry.getValue()) {
                             if (status.getStatus() == Status.critical || status.getStatus() == Status.warning) {
-                                for (URL endpoint : onlineResourceEndpoints) {
-                                    if (endpoint.toString() != null && endpoint.toString().contains(entry.getKey())) {
-                                        failingHosts.add(entry.getKey());
-                                        break;
-                                    }
+                                if (onlineResourceEndpoints.contains(entry.getKey())) {
+                                    failingHosts.add(entry.getKey());
+                                    break;
                                 }
-
                             }
                         }
                     }

--- a/src/main/java/org/auscope/portal/core/view/ViewCSWRecordFactory.java
+++ b/src/main/java/org/auscope/portal/core/view/ViewCSWRecordFactory.java
@@ -148,7 +148,7 @@ public class ViewCSWRecordFactory {
         obj.put("url", res.getLinkage().toString());
         obj.put("type", res.getType().name());
         obj.put("name", res.getName());
-        obj.put("description", res.getDescription().toString());
+        obj.put("description", res.getDescription());
         obj.put("version", res.getVersion());
         obj.put("applicationProfile", res.getApplicationProfile());
         return obj;

--- a/src/test/java/org/auscope/portal/core/server/controllers/TestBaseCSWController.java
+++ b/src/test/java/org/auscope/portal/core/server/controllers/TestBaseCSWController.java
@@ -1,5 +1,6 @@
 package org.auscope.portal.core.server.controllers;
 
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -7,6 +8,8 @@ import java.util.List;
 
 import org.auscope.portal.core.services.Nagios4CachedService;
 import org.auscope.portal.core.services.PortalServiceException;
+import org.auscope.portal.core.services.responses.csw.AbstractCSWOnlineResource;
+import org.auscope.portal.core.services.responses.csw.CSWOnlineResourceImpl;
 import org.auscope.portal.core.services.responses.csw.CSWRecord;
 import org.auscope.portal.core.services.responses.nagios.ServiceStatusResponse;
 import org.auscope.portal.core.services.responses.nagios.ServiceStatusResponse.Status;
@@ -46,6 +49,16 @@ public class TestBaseCSWController extends PortalTestClass {
      */
     @Test
     public void testNagiosErrorHandling() throws Exception {
+        CSWOnlineResourceImpl or1 = new CSWOnlineResourceImpl(new URL("http://host.name.1"), null, "Host Name 1", null);
+        CSWOnlineResourceImpl or2 = new CSWOnlineResourceImpl(new URL("http://host.name.2"), null, "Host Name 2", null);
+        CSWOnlineResourceImpl or3 = new CSWOnlineResourceImpl(new URL("http://host.name.3"), null, "Host Name 3", null);
+        CSWOnlineResourceImpl or4 = new CSWOnlineResourceImpl(new URL("http://host.name.4"), null, "Host Name 4", null);
+
+
+        CSWRecord mockBelongingRecord = new CSWRecord();
+
+        mockBelongingRecord.setOnlineResources(new AbstractCSWOnlineResource[] {or1, or2, or3, or4});
+
         KnownLayer kl1 = new KnownLayer("kl1", new KnownLayerSelector() {
             @Override
             public RelationType isRelatedRecord(CSWRecord record) {
@@ -74,10 +87,10 @@ public class TestBaseCSWController extends PortalTestClass {
         kl2.setNagiosHostGroup("hg2");
         kl4.setNagiosHostGroup("hg4");
         List<KnownLayerAndRecords> knownLayers = Arrays.asList(
-                new KnownLayerAndRecords(kl1, new ArrayList<CSWRecord>(), new ArrayList<CSWRecord>()),
-                new KnownLayerAndRecords(kl2, new ArrayList<CSWRecord>(), new ArrayList<CSWRecord>()),
-                new KnownLayerAndRecords(kl3, new ArrayList<CSWRecord>(), new ArrayList<CSWRecord>()),
-                new KnownLayerAndRecords(kl4, new ArrayList<CSWRecord>(), new ArrayList<CSWRecord>()));
+                new KnownLayerAndRecords(kl1, Arrays.asList(new CSWRecord[]{mockBelongingRecord}), new ArrayList<CSWRecord>()),
+                new KnownLayerAndRecords(kl2, Arrays.asList(new CSWRecord[]{mockBelongingRecord}), new ArrayList<CSWRecord>()),
+                new KnownLayerAndRecords(kl3, Arrays.asList(new CSWRecord[]{mockBelongingRecord}), new ArrayList<CSWRecord>()),
+                new KnownLayerAndRecords(kl4, Arrays.asList(new CSWRecord[]{mockBelongingRecord}), new ArrayList<CSWRecord>()));
 
         final HashMap<String, List<ServiceStatusResponse>> hg1Response = new HashMap<String, List<ServiceStatusResponse>>();
         final HashMap<String, List<ServiceStatusResponse>> hg2Response = new HashMap<String, List<ServiceStatusResponse>>();


### PR DESCRIPTION
Some KnownLayers belong to host groups which have more service endpoints in them than are part of the layer's set of records. Here we check what endpoints are associated with the KnownLayer, then see if the flagging host is in that set of layers.